### PR TITLE
Change h_heading to also scan toc title

### DIFF
--- a/yalafi/handlers.py
+++ b/yalafi/handlers.py
@@ -85,13 +85,17 @@ def h_newtheorem(parser, buf, mac, args, delim, pos):
 
 #   heading macros: append '.', unless last char in parms.heading_punct
 #
+
 def h_heading(parser, buf, mac, args, delim, pos):
-    arg = args[2]
-    txt = parser.get_text_expanded(arg).strip()
-    if (txt and parser.parms.heading_punct
-                and txt[-1] not in parser.parms.heading_punct):
-        arg.append(defs.TextToken(arg[-1].pos, '.'))
-    return arg
+    int_args = args[1:3]
+    for arg in int_args:
+        txt = parser.get_text_expanded(arg).strip()
+        if (txt and parser.parms.heading_punct
+                    and txt[-1] not in parser.parms.heading_punct):
+            arg.append(defs.TextToken(arg[-1].pos, '.'))
+        if arg:
+            arg.append(defs.SpaceToken(arg[-1].pos, ' '))
+    return int_args[0] + int_args[1]
 
 #   \phantom, \hphantom
 #


### PR DESCRIPTION
This is the continuation of #196 after the transfer. Old discussion:

@torik42:
> So far only the directly printed title of the commands `\section` and similar are checked. It would be nice if also the title for the table of contents given as an optional argument, i.e. `\section[Short Title]{Long Title}` would be checked.
> 
> My suggestion is to put it in the output as is done for the usual title, i.e. `\section[a]{b}` would be parsed as `a. b. `. The whitespace in the end even has the advantage that `\section{Title}Some text` will not yield a mistake any more.
> 
> Since there are a lot of tests, I did not adapt them yet. If you agree to the proposed changes, @matze-dd, I could do so.

@torik42:
> One could maybe even make the addition of the dot a function by its own. This would make it easier to use it in other packages as well. I will need a similar thing in the `beamer` class, for example.
> 
> Something like
> 
> ```python
> def append_dot(parser, toks):
>     txt = parser.get_text_expanded(toks).strip()
>     if (txt and parser.parms.heading_punct
>             and txt[-1] not in parser.parms.heading_punct):
>         toks.append(TextToken(toks[-1].pos, '.'))
>     toks.append(SpaceToken(toks[-1].pos, ' '))
> ```