### PR TITLE
Include new glossaries format

### DIFF
--- a/yalafi/packages/glossaries.py
+++ b/yalafi/packages/glossaries.py
@@ -83,7 +83,11 @@ def init_module(parser, options, position):
         Macro(parms, '\\newglossaryentry', args='AA', repl=h_newglossaryentry),
 
         # this is for reading the .glsdefs database
+        # for glossaries < 4.47
         Macro(parms, '\\gls@defglossaryentry', args='AA',
+                                                    repl=h_parse_glsdefs),
+        # for newer glossaries
+        Macro(parms, '\\glsdefs@newdocentry', args='AA',
                                                     repl=h_parse_glsdefs),
 
     ]


### PR DESCRIPTION
In version 4.47 glossaries changed the format, see https://www.ctan.org/ctan-ann/id/mailman.4003.1632505415.2581.ctan-ann@ctan.org
main relevant change:
old: `\gls@defglossaryentry`
new: `\glsdefs@newdocentry`

As for testing, the `.glsdefs` files for the tests are checked in. One could create a new test file, or dynamically create the `.glsdefs`, or not test at all. What do you think?