### PR TITLE
Feature install action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,33 @@ jobs:
     - name: Test with module pytest
       run: |
         python -m pytest tests
-
+  test-install:
+    name: Test import of packages after local install
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+    steps:
+      - uses: actions/checkout@master
+        with:
+          path: YaLafi
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Install pytest
+        run: python -m pip install pytest
+      - name: Install YaLafi
+        run: |
+          cd YaLafi
+          pip install .
+      - name: Check if yalafi is installed and accessible
+        run: python -c "import yalafi"
+      - name: Check if yalafi.shell is installed and accessible
+        run: python -c "import yalafi.shell"
+      - name: Execute the tests (without adding the pwd to pythonpath)
+        run: |
+          cd YaLafi
+          pytest tests/test_shell/test_shell.py


### PR DESCRIPTION
Add new job to test.yml for testing installation, responding to #235. This takes care of the first part, testing the local installation.

The shell test is not included (yet), as there is a dependence on the local path. If I `cd` to the package directory to have this path available, it is not a test of the execution anymore IIUC. Any idea for a fix there, or should we just leave that test out?

Regarding the test after pushing to PyPi: my understanding is that the GitHub Actions are executed responding to changes in the repository. This `publish.yml` would have to be executed after a push to PyPi, do you know of a way to trigger this?
